### PR TITLE
ci: update Node matrix to 18.x/20.x, add yarn cache, bump action versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,18 +13,19 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [18.x, 20.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
+        cache: 'yarn'
     - run: yarn
     - run: npm run lint
     - run: npm run type-check
     - run: npm test
     - run: npm run bundle
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v4


### PR DESCRIPTION
## Summary

- Replace EOL Node versions (10, 12, 14, 16) with active LTS versions (18.x, 20.x)
- Add yarn dependency caching via the `cache` parameter on `actions/setup-node`, eliminating a full `yarn install` on every run
- Bump `actions/checkout` and `actions/setup-node` from v2 → v4
- Bump `codecov/codecov-action` from v1 → v4