### PR TITLE
Migrate DuotoneImage to functional component with hooks

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -1,5 +1,5 @@
 /* @flow */
-import React, { Component } from 'react';
+import React, { useState, useEffect } from 'react';
 import { omit } from 'lodash';
 import createDuotoneImage from './create-duotone-image';
 
@@ -11,51 +11,33 @@ type Props = {
   secondaryColor: string,
 };
 
-type State = {
-  duotoneImageSrc: string | null,
-};
+function DuotoneImage(props: Props) {
+  const { src, width, height, primaryColor, secondaryColor } = props;
+  const [duotoneImageSrc, setDuotoneImageSrc] = useState('');
 
-class DuotoneImage extends Component<Props, State> {
-  constructor() {
-    super();
-    this.state = { duotoneImageSrc: '' };
-  }
-  componentWillMount(): void {
-    this.getDuotoneImage();
-  }
-  componentWillReceiveProps(): void {
-    this.getDuotoneImage();
-  }
-  getDuotoneImage(): void {
+  useEffect(() => {
     const img = new Image();
 
-    if (this.props.width) {
-      img.width = this.props.width;
+    if (width) {
+      img.width = width;
     }
-    if (this.props.height) {
-      img.height = this.props.height;
+    if (height) {
+      img.height = height;
     }
 
-    img.src = this.props.src;
+    img.src = src;
     img.onload = () => {
-      this.setState({
-        duotoneImageSrc: createDuotoneImage(
-          img,
-          this.props.primaryColor,
-          this.props.secondaryColor,
-        ),
-      });
+      setDuotoneImageSrc(createDuotoneImage(img, primaryColor, secondaryColor));
     };
-  }
-  render(): any {
-    const additionalAttributes = omit(this.props, [
-      'primaryColor',
-      'secondaryColor',
-      'src',
-    ]);
+  }, [src, width, height, primaryColor, secondaryColor]);
 
-    return <img {...additionalAttributes} src={this.state.duotoneImageSrc} />;
-  }
+  const additionalAttributes = omit(props, [
+    'primaryColor',
+    'secondaryColor',
+    'src',
+  ]);
+
+  return <img {...additionalAttributes} src={duotoneImageSrc} />;
 }
 
 export default DuotoneImage;


### PR DESCRIPTION
## Summary

- Replace deprecated `componentWillMount` and `componentWillReceiveProps` lifecycle methods with a functional component using `useState` and `useEffect`
- Remove the `State` Flow type and class boilerplate (`constructor`, class body)
- The `useEffect` dependency array `[src, width, height, primaryColor, secondaryColor]` preserves the previous behaviour of re-fetching the duotone image whenever any relevant prop changes

## Changes

`src/component.js`:
- `class DuotoneImage extends Component` → `function DuotoneImage(props)`
- `this.state.duotoneImageSrc` → `useState('')`
- `componentWillMount` + `componentWillReceiveProps` + `getDuotoneImage` → single `useEffect` with full dependency array
- `this.setState(...)` → `setDuotoneImageSrc(...)`

## Test plan

- [ ] Existing snapshot tests still pass (`src=""` on initial render matches previous behaviour, since `img.onload` was always async)
- [ ] Manually verify duotone effect applies correctly when props change

https://claude.ai/code/session_01PVRFm2Xpri98jWouyUzKjp