### PR TITLE
fix: correct Flow type annotations and re-enable ESLint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,33 +1,27 @@
 {
-  "extends": [
-    "airbnb",
-    "prettier",
-    "prettier/flowtype",
-    "prettier/react"
-  ],
+  "extends": ["airbnb", "prettier"],
   "parser": "babel-eslint",
   "env": {
     "browser": true,
     "node": true
   },
   "plugins": [
-  	"prettier"
+    "prettier"
   ],
   "rules": {
     "import/no-extraneous-dependencies": 0,
     "no-plusplus": [
       "error",
       {
-      	"allowForLoopAfterthoughts": true
+        "allowForLoopAfterthoughts": true
       }
     ],
     "no-return-assign": 0,
     "react/prefer-es6-class": 0,
-    "react/prefer-stateless-function": 0,
+    "react/prefer-stateless-function": "warn",
     "react/jsx-filename-extension": 0,
     "react/require-default-props": 0,
     "jsx-a11y/img-has-alt": 0,
-    "react/sort-comp": 0,
     "react/no-unused-prop-types": 0,
     "react/prop-types": 0,
     "prettier/prettier": [
@@ -38,6 +32,6 @@
         "printWidth": 80,
         "jsxBracketSameLine": true
       }
-    ],
+    ]
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,9 @@
     "browser": true,
     "node": true
   },
+  "globals": {
+    "React$Node": "readonly"
+  },
   "plugins": [
     "prettier"
   ],

--- a/src/component.js
+++ b/src/component.js
@@ -4,7 +4,7 @@ import { omit } from 'lodash';
 import createDuotoneImage from './create-duotone-image';
 
 type Props = {
-  src: any,
+  src: string,
   width?: number,
   height?: number,
   primaryColor: string,
@@ -20,9 +20,11 @@ class DuotoneImage extends Component<Props, State> {
     super();
     this.state = { duotoneImageSrc: '' };
   }
+  /* $FlowFixMe */
   componentWillMount(): void {
     this.getDuotoneImage();
   }
+  /* $FlowFixMe */
   componentWillReceiveProps(): void {
     this.getDuotoneImage();
   }
@@ -47,7 +49,7 @@ class DuotoneImage extends Component<Props, State> {
       });
     };
   }
-  render(): any {
+  render(): React$Node {
     const additionalAttributes = omit(this.props, [
       'primaryColor',
       'secondaryColor',

--- a/src/hex-to-rgb.js
+++ b/src/hex-to-rgb.js
@@ -1,4 +1,4 @@
-export default function hexToRgb(hex: string): Array<string> {
+export default function hexToRgb(hex: string): Array<number> | null {
   const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
   return result
     ? [


### PR DESCRIPTION
## Summary

### `src/hex-to-rgb.js`
- Fixed the return type from `Array<string>` to `Array<number> | null`. The function uses `parseInt` (which returns numbers, not strings) and can return `null` when the regex does not match — neither case was reflected in the original annotation.

### `src/component.js`
- Narrowed the `src` prop type from `any` to `string` — the prop is always passed as an image URL string.
- Changed `render()` return type from `any` to `React$Node` — the correct Flow type for React render output.
- Added `/* $FlowFixMe */` before `componentWillMount` and `componentWillReceiveProps` to suppress Flow errors on these deprecated-but-still-used lifecycle methods without silently widening their types.

### `.eslintrc`
- Removed deprecated `"prettier/flowtype"` and `"prettier/react"` entries from `extends` (dropped in newer `eslint-config-prettier`).
- Removed `"react/sort-comp": 0` override — the component already follows the correct ordering (constructor → lifecycle → custom methods → render), so no suppression is needed.
- Changed `"react/prefer-stateless-function"` from `0` (off) to `"warn"` — the class exists only because of lifecycle methods; a warn surfaces it for future refactoring without blocking CI.
- Kept `react/prop-types: 0`, `react/require-default-props: 0`, and `jsx-a11y/img-has-alt: 0` disabled: Flow types cover prop validation, and the `alt` attribute is forwarded via spread so the linter cannot detect it statically.

## Test plan
- [ ] Run `eslint src/` and confirm no new errors are introduced
- [ ] Run Flow type checker and confirm no new Flow errors (the `$FlowFixMe` comments should suppress the lifecycle-method warnings)
- [ ] Verify the component renders correctly in a browser/Storybook after the type-only changes

https://claude.ai/code/session_01UsFSzZubrjdqsbecspz4Bj