### PR TITLE
test: expand coverage — behavioral assertions, error paths, jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.js$': 'babel-jest',
+  },
+  coverageThreshold: {
+    global: {
+      lines: 70,
+      functions: 70,
+      branches: 60,
+    },
+  },
+};

--- a/src/__tests__/__snapshots__/component.test.js.snap
+++ b/src/__tests__/__snapshots__/component.test.js.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DuotoneImage component matches snapshot 1`] = `
+<img
+  src=""
+/>
+`;
+
 exports[`DuotoneImageComponent renders additional attributes correctly 1`] = `
 <img
   alt="GitHub Avatar"

--- a/src/__tests__/component.test.js
+++ b/src/__tests__/component.test.js
@@ -11,12 +11,16 @@ const defaultProps = {
 
 describe('DuotoneImage component', () => {
   it('renders an img element', () => {
-    const tree = renderer.create(<DuotoneImageComponent {...defaultProps} />).toJSON();
+    const tree = renderer
+      .create(<DuotoneImageComponent {...defaultProps} />)
+      .toJSON();
     expect(tree.type).toBe('img');
   });
 
   it('renders with initial empty src (image not yet loaded)', () => {
-    const tree = renderer.create(<DuotoneImageComponent {...defaultProps} />).toJSON();
+    const tree = renderer
+      .create(<DuotoneImageComponent {...defaultProps} />)
+      .toJSON();
     // Before the image loads, duotoneImageSrc is empty string
     expect(tree.props.src).toBe('');
   });
@@ -30,7 +34,9 @@ describe('DuotoneImage component', () => {
 
   it('passes through width and height attributes', () => {
     const tree = renderer
-      .create(<DuotoneImageComponent {...defaultProps} width={100} height={200} />)
+      .create(
+        <DuotoneImageComponent {...defaultProps} width={100} height={200} />,
+      )
       .toJSON();
     expect(tree.props.width).toBe(100);
     expect(tree.props.height).toBe(200);
@@ -38,26 +44,38 @@ describe('DuotoneImage component', () => {
 
   it('passes through arbitrary HTML attributes', () => {
     const tree = renderer
-      .create(<DuotoneImageComponent {...defaultProps} className="my-image" data-testid="img" />)
+      .create(
+        <DuotoneImageComponent
+          {...defaultProps}
+          className="my-image"
+          data-testid="img"
+        />,
+      )
       .toJSON();
     expect(tree.props.className).toBe('my-image');
     expect(tree.props['data-testid']).toBe('img');
   });
 
   it('does not pass primaryColor or secondaryColor to the img element', () => {
-    const tree = renderer.create(<DuotoneImageComponent {...defaultProps} />).toJSON();
+    const tree = renderer
+      .create(<DuotoneImageComponent {...defaultProps} />)
+      .toJSON();
     expect(tree.props.primaryColor).toBeUndefined();
     expect(tree.props.secondaryColor).toBeUndefined();
   });
 
   it('does not pass src prop directly to img (uses processed duotone src)', () => {
     // The original src is processed, not forwarded as-is
-    const tree = renderer.create(<DuotoneImageComponent {...defaultProps} />).toJSON();
+    const tree = renderer
+      .create(<DuotoneImageComponent {...defaultProps} />)
+      .toJSON();
     expect(tree.props.src).not.toBe(defaultProps.src);
   });
 
   it('matches snapshot', () => {
-    const tree = renderer.create(<DuotoneImageComponent {...defaultProps} />).toJSON();
+    const tree = renderer
+      .create(<DuotoneImageComponent {...defaultProps} />)
+      .toJSON();
     expect(tree).toMatchSnapshot();
   });
 });

--- a/src/__tests__/component.test.js
+++ b/src/__tests__/component.test.js
@@ -3,35 +3,61 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import DuotoneImageComponent from '../component';
 
-describe('DuotoneImageComponent', () => {
-  it('renders the image correctly', () => {
-    const tree = renderer
-      .create(
-        <DuotoneImageComponent
-          src="https://avatars.githubusercontent.com/u/7649376?v=3"
-          primaryColor="#66FA75"
-          secondaryColor="#1904C7"
-        />,
-      )
-      .toJSON();
+const defaultProps = {
+  src: 'test-image.jpg',
+  primaryColor: '#66FA75',
+  secondaryColor: '#1904C7',
+};
 
-    expect(tree).toMatchSnapshot();
+describe('DuotoneImage component', () => {
+  it('renders an img element', () => {
+    const tree = renderer.create(<DuotoneImageComponent {...defaultProps} />).toJSON();
+    expect(tree.type).toBe('img');
   });
 
-  it('renders additional attributes correctly', () => {
-    const tree = renderer
-      .create(
-        <DuotoneImageComponent
-          src="https://avatars.githubusercontent.com/u/7649376?v=3"
-          primaryColor="#66FA75"
-          secondaryColor="#1904C7"
-          alt="GitHub Avatar"
-          height="56"
-          width="56"
-        />,
-      )
-      .toJSON();
+  it('renders with initial empty src (image not yet loaded)', () => {
+    const tree = renderer.create(<DuotoneImageComponent {...defaultProps} />).toJSON();
+    // Before the image loads, duotoneImageSrc is empty string
+    expect(tree.props.src).toBe('');
+  });
 
+  it('passes through alt attribute', () => {
+    const tree = renderer
+      .create(<DuotoneImageComponent {...defaultProps} alt="test alt text" />)
+      .toJSON();
+    expect(tree.props.alt).toBe('test alt text');
+  });
+
+  it('passes through width and height attributes', () => {
+    const tree = renderer
+      .create(<DuotoneImageComponent {...defaultProps} width={100} height={200} />)
+      .toJSON();
+    expect(tree.props.width).toBe(100);
+    expect(tree.props.height).toBe(200);
+  });
+
+  it('passes through arbitrary HTML attributes', () => {
+    const tree = renderer
+      .create(<DuotoneImageComponent {...defaultProps} className="my-image" data-testid="img" />)
+      .toJSON();
+    expect(tree.props.className).toBe('my-image');
+    expect(tree.props['data-testid']).toBe('img');
+  });
+
+  it('does not pass primaryColor or secondaryColor to the img element', () => {
+    const tree = renderer.create(<DuotoneImageComponent {...defaultProps} />).toJSON();
+    expect(tree.props.primaryColor).toBeUndefined();
+    expect(tree.props.secondaryColor).toBeUndefined();
+  });
+
+  it('does not pass src prop directly to img (uses processed duotone src)', () => {
+    // The original src is processed, not forwarded as-is
+    const tree = renderer.create(<DuotoneImageComponent {...defaultProps} />).toJSON();
+    expect(tree.props.src).not.toBe(defaultProps.src);
+  });
+
+  it('matches snapshot', () => {
+    const tree = renderer.create(<DuotoneImageComponent {...defaultProps} />).toJSON();
     expect(tree).toMatchSnapshot();
   });
 });

--- a/src/__tests__/create-duotone-gradient.test.js
+++ b/src/__tests__/create-duotone-gradient.test.js
@@ -1,13 +1,54 @@
-/* global describe, it, expect */
+/* global describe, it, expect, beforeEach */
 import createDuotoneGradient from '../create-duotone-gradient';
 
 const primaryColor = [102, 250, 117];
 const secondaryColor = [25, 4, 199];
 
-describe('create-duotone-gradient', () => {
-  it('should return the correct gradient map', () => {
-    expect(
-      createDuotoneGradient(primaryColor, secondaryColor),
-    ).toMatchSnapshot();
+describe('createDuotoneGradient', () => {
+  let gradient;
+
+  beforeEach(() => {
+    gradient = createDuotoneGradient(primaryColor, secondaryColor);
+  });
+
+  it('returns an array of 256 entries', () => {
+    expect(gradient).toHaveLength(256);
+  });
+
+  it('each entry is an array of 3 numbers', () => {
+    gradient.forEach(entry => {
+      expect(entry).toHaveLength(3);
+      entry.forEach(value => expect(typeof value).toBe('number'));
+    });
+  });
+
+  it('all RGB values are in range 0–255', () => {
+    gradient.forEach(entry => {
+      entry.forEach(value => {
+        expect(value).toBeGreaterThanOrEqual(0);
+        expect(value).toBeLessThanOrEqual(255);
+      });
+    });
+  });
+
+  it('index 0 (darkest) equals the secondary color', () => {
+    // At i=0, ratio=0, so result = secondaryColor * 1 = secondaryColor
+    expect(gradient[0]).toEqual(secondaryColor);
+  });
+
+  it('index 255 (lightest) equals the primary color', () => {
+    // At i=255, ratio=255/255=1, so result = primaryColor * 1 = primaryColor
+    expect(gradient[255]).toEqual(primaryColor);
+  });
+
+  it('intermediate values are interpolated between the two colors', () => {
+    const midpoint = gradient[127];
+    // Midpoint should be roughly halfway between primary and secondary
+    midpoint.forEach((value, channel) => {
+      const expected = Math.round(
+        primaryColor[channel] * (127 / 255) + secondaryColor[channel] * (1 - 127 / 255)
+      );
+      expect(value).toBe(expected);
+    });
   });
 });

--- a/src/__tests__/create-duotone-gradient.test.js
+++ b/src/__tests__/create-duotone-gradient.test.js
@@ -46,7 +46,8 @@ describe('createDuotoneGradient', () => {
     // Midpoint should be roughly halfway between primary and secondary
     midpoint.forEach((value, channel) => {
       const expected = Math.round(
-        primaryColor[channel] * (127 / 255) + secondaryColor[channel] * (1 - 127 / 255)
+        primaryColor[channel] * (127 / 255) +
+          secondaryColor[channel] * (1 - 127 / 255),
       );
       expect(value).toBe(expected);
     });

--- a/src/__tests__/create-duotone-image.test.js
+++ b/src/__tests__/create-duotone-image.test.js
@@ -5,41 +5,41 @@ describe('createDuotoneImage', () => {
   describe('argument validation', () => {
     it('throws when imageElement is null', () => {
       expect(() => createDuotoneImage(null, '#ffffff', '#000000')).toThrow(
-        'Invalid arguments, You need to pass an image element'
+        'Invalid arguments, You need to pass an image element',
       );
     });
 
     it('throws when imageElement is undefined', () => {
       expect(() => createDuotoneImage(undefined, '#ffffff', '#000000')).toThrow(
-        'Invalid arguments, You need to pass an image element'
+        'Invalid arguments, You need to pass an image element',
       );
     });
 
     it('throws when imageElement is not an HTMLImageElement', () => {
       const div = document.createElement('div');
       expect(() => createDuotoneImage(div, '#ffffff', '#000000')).toThrow(
-        'Invalid arguments, You need to pass an image element'
+        'Invalid arguments, You need to pass an image element',
       );
     });
 
     it('throws when primaryColor is missing', () => {
       const img = new Image();
       expect(() => createDuotoneImage(img, null, '#000000')).toThrow(
-        'Invalid arguments, You need to pass a primary and secondary color'
+        'Invalid arguments, You need to pass a primary and secondary color',
       );
     });
 
     it('throws when secondaryColor is missing', () => {
       const img = new Image();
       expect(() => createDuotoneImage(img, '#ffffff', null)).toThrow(
-        'Invalid arguments, You need to pass a primary and secondary color'
+        'Invalid arguments, You need to pass a primary and secondary color',
       );
     });
 
     it('throws when both colors are missing', () => {
       const img = new Image();
       expect(() => createDuotoneImage(img, null, null)).toThrow(
-        'Invalid arguments, You need to pass a primary and secondary color'
+        'Invalid arguments, You need to pass a primary and secondary color',
       );
     });
   });

--- a/src/__tests__/create-duotone-image.test.js
+++ b/src/__tests__/create-duotone-image.test.js
@@ -1,0 +1,62 @@
+/* global describe, it, expect, beforeEach */
+import createDuotoneImage from '../create-duotone-image';
+
+describe('createDuotoneImage', () => {
+  describe('argument validation', () => {
+    it('throws when imageElement is null', () => {
+      expect(() => createDuotoneImage(null, '#ffffff', '#000000')).toThrow(
+        'Invalid arguments, You need to pass an image element'
+      );
+    });
+
+    it('throws when imageElement is undefined', () => {
+      expect(() => createDuotoneImage(undefined, '#ffffff', '#000000')).toThrow(
+        'Invalid arguments, You need to pass an image element'
+      );
+    });
+
+    it('throws when imageElement is not an HTMLImageElement', () => {
+      const div = document.createElement('div');
+      expect(() => createDuotoneImage(div, '#ffffff', '#000000')).toThrow(
+        'Invalid arguments, You need to pass an image element'
+      );
+    });
+
+    it('throws when primaryColor is missing', () => {
+      const img = new Image();
+      expect(() => createDuotoneImage(img, null, '#000000')).toThrow(
+        'Invalid arguments, You need to pass a primary and secondary color'
+      );
+    });
+
+    it('throws when secondaryColor is missing', () => {
+      const img = new Image();
+      expect(() => createDuotoneImage(img, '#ffffff', null)).toThrow(
+        'Invalid arguments, You need to pass a primary and secondary color'
+      );
+    });
+
+    it('throws when both colors are missing', () => {
+      const img = new Image();
+      expect(() => createDuotoneImage(img, null, null)).toThrow(
+        'Invalid arguments, You need to pass a primary and secondary color'
+      );
+    });
+  });
+
+  describe('canvas context unavailable', () => {
+    it('returns null when canvas 2d context is not available', () => {
+      // Mock getContext to return null (simulates environments without canvas support)
+      const originalGetContext = HTMLCanvasElement.prototype.getContext;
+      HTMLCanvasElement.prototype.getContext = () => null;
+
+      const img = new Image();
+      // Must pass validation: img is HTMLImageElement and colors are provided
+      // Image will have 0x0 dimensions, so pixel loop won't run
+      const result = createDuotoneImage(img, '#ffffff', '#000000');
+      expect(result).toBeNull();
+
+      HTMLCanvasElement.prototype.getContext = originalGetContext;
+    });
+  });
+});

--- a/src/__tests__/hex-to-rgb.test.js
+++ b/src/__tests__/hex-to-rgb.test.js
@@ -1,13 +1,47 @@
 /* global describe, it, expect */
 import hexToRgb from '../hex-to-rgb';
 
-describe('hex-to-rgb', () => {
-  it('should return the correct rgb value', () => {
-    expect(hexToRgb('#cccccc')).toEqual([204, 204, 204]);
-    expect(hexToRgb('#3424BF')).toEqual([52, 36, 191]);
+describe('hexToRgb', () => {
+  describe('valid hex values', () => {
+    it('parses lowercase hex with # prefix', () => {
+      expect(hexToRgb('#cccccc')).toEqual([204, 204, 204]);
+    });
+
+    it('parses mixed-case hex with # prefix', () => {
+      expect(hexToRgb('#3424BF')).toEqual([52, 36, 191]);
+    });
+
+    it('parses hex without # prefix', () => {
+      expect(hexToRgb('cccccc')).toEqual([204, 204, 204]);
+    });
+
+    it('parses black (#000000)', () => {
+      expect(hexToRgb('#000000')).toEqual([0, 0, 0]);
+    });
+
+    it('parses white (#ffffff)', () => {
+      expect(hexToRgb('#ffffff')).toEqual([255, 255, 255]);
+    });
+
+    it('returns numbers, not strings', () => {
+      const result = hexToRgb('#aabbcc');
+      expect(typeof result[0]).toBe('number');
+      expect(typeof result[1]).toBe('number');
+      expect(typeof result[2]).toBe('number');
+    });
   });
 
-  it('should return null if input is not a hex value', () => {
-    expect(hexToRgb('#defghi')).toBeNull();
+  describe('invalid hex values', () => {
+    it('returns null for invalid hex characters', () => {
+      expect(hexToRgb('#defghi')).toBeNull();
+    });
+
+    it('returns null for 3-character shorthand hex', () => {
+      expect(hexToRgb('#abc')).toBeNull();
+    });
+
+    it('returns null for empty string', () => {
+      expect(hexToRgb('')).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Add `jest.config.js` with `testEnvironment: 'jsdom'`, babel transform, and coverage thresholds (70% lines/functions, 60% branches)
- Replace `createDuotoneGradient` snapshot test with 6 behavioral assertions (length, value range, interpolation, boundary values)
- Expand `hexToRgb` tests from 2 to 9 cases (no-# prefix, uppercase, shorthand, types, edge cases)
- Add new `create-duotone-image.test.js` with 7 tests covering all error-throwing paths and the null-canvas fallback
- Replace `DuotoneImage` snapshot tests with 8 behavioral assertions (element type, attribute pass-through, prop filtering)

## Test plan
- [ ] Run `npm test -- --coverage` and confirm all new tests pass
- [ ] Verify coverage thresholds are met