### PR TITLE
feat: add TypeScript type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,46 @@
+import * as React from 'react';
+
+/**
+ * Props for the DuotoneImage component.
+ * All standard HTML img attributes are also accepted and forwarded to the
+ * underlying <img> element (e.g. alt, className, width, height, style).
+ */
+export interface DuotoneImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+  /** URL of the source image to apply the duotone effect to. */
+  src: string;
+  /** Hex color string for the highlight (light) tone, e.g. `"#FBFBFB"`. */
+  primaryColor: string;
+  /** Hex color string for the shadow (dark) tone, e.g. `"#283B6B"`. */
+  secondaryColor: string;
+}
+
+/**
+ * A React component that renders an image with a duotone color effect applied
+ * via an HTML5 Canvas. The processed image is displayed as a data URL.
+ *
+ * @example
+ * <DuotoneImage
+ *   src="photo.jpg"
+ *   primaryColor="#FBFBFB"
+ *   secondaryColor="#283B6B"
+ *   alt="Duotone photo"
+ * />
+ */
+export class DuotoneImage extends React.Component<DuotoneImageProps> {}
+
+/**
+ * Applies a duotone color effect to an HTMLImageElement using Canvas 2D.
+ *
+ * @param imageElement - A fully loaded HTMLImageElement.
+ * @param primaryColor - Hex color for the highlight tone (e.g. `"#FBFBFB"`).
+ * @param secondaryColor - Hex color for the shadow tone (e.g. `"#283B6B"`).
+ * @returns A data URL string of the processed image, or `null` if the Canvas
+ *          2D context is unavailable.
+ * @throws {Error} If `imageElement` is not an HTMLImageElement.
+ * @throws {Error} If `primaryColor` or `secondaryColor` is falsy.
+ */
+export function createDuotoneImage(
+  imageElement: HTMLImageElement,
+  primaryColor: string,
+  secondaryColor: string,
+): string | null;

--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "2.1.1",
   "description": "React Duotone Component",
   "main": "lib/main.js",
+  "types": "index.d.ts",
   "files": [
     "dist",
-    "lib"
+    "lib",
+    "index.d.ts"
   ],
   "scripts": {
     "build:umd": "webpack --devtool source-map --config webpack.build.js",


### PR DESCRIPTION
## Summary

- Add `index.d.ts` with TypeScript definitions for the full public API:
  - `DuotoneImageProps` interface extending `React.ImgHTMLAttributes<HTMLImageElement>` so all standard `<img>` props are accepted
  - `DuotoneImage` class component typed with `DuotoneImageProps`
  - `createDuotoneImage` function with full parameter and return type annotations including JSDoc for thrown errors
- Add `"types": "index.d.ts"` to `package.json` so TypeScript resolves the definitions automatically
- Add `index.d.ts` to the `"files"` array so it's included in the npm publish

## Test plan
- [ ] Run `npx tsc --strict index.d.ts --noEmit` to validate type syntax
- [ ] Create a small TypeScript consumer and verify IDE autocomplete works
- [ ] Confirm `npm pack` includes `index.d.ts`