### PR TITLE
ci: update Node.js test matrix to 20.x, 22.x, and 24.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x, 24.x]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Remove Node.js 18.x from the CI test matrix (reached EOL in April 2025)
- Add Node.js 22.x (Active LTS) and 24.x (Current) to keep coverage aligned with supported releases

## Test plan

- [ ] Verify CI passes on Node.js 20.x, 22.x, and 24.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)