### PR TITLE
chore: release 3.0.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,12 @@
 ### Proposed solution
+
 <!-- Which specific problem does this PR solve and how? -->
 
 ### Tradeoffs
+
 <!-- What are the drawbacks of this solution? Are there alternatives ones? -->
 <!-- Think of performance, build time, usability, complexity, coupling…) -->
 
 ### Testing Done
+
 <!-- Have you confirmed this feature works? -->

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm ci
+    - run: npm run prettier:check
     - run: npm run lint
     - run: npm run type-check
     - run: npm test

--- a/README.md
+++ b/README.md
@@ -1,37 +1,75 @@
-# React Duotone [![Build Status](https://github.com/nagelflorian/react-duotone/actions/workflows/main.yml/badge.svg)](https://github.com/nagelflorian/react-duotone/actions) ![[Airbnb JavaScript Style Guide](https://github.com/airbnb/javascript)](https://img.shields.io/badge/code--style-airbnb-blue.svg) [![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
+# react-duotone
 
-![Example Duotone Image](https://cloud.githubusercontent.com/assets/7649376/19024780/e0fac730-890b-11e6-9640-1e2f604614e3.png)
+[![Build Status](https://github.com/nagelflorian/react-duotone/actions/workflows/main.yml/badge.svg)](https://github.com/nagelflorian/react-duotone/actions) [![npm version](https://img.shields.io/npm/v/react-duotone.svg)](https://www.npmjs.com/package/react-duotone) [![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
+
+Apply a [duotone](https://duotones.co/) color effect to images in React. Renders via HTML5 Canvas and returns the result as a data URL.
+
+## Requirements
+
+- React 15, 16, 17, or 18
 
 ## Installation
 
-```
-npm install --save react-duotone
+```bash
+npm install react-duotone
+# or
+yarn add react-duotone
 ```
 
-## How to use
+## Usage
 
-```JavaScript
-import React, { Component } from 'react';
-import { render } from 'react-dom';
+### `DuotoneImage` component
+
+The simplest way to use the library. Accepts all standard `<img>` attributes in addition to the props below.
+
+```tsx
 import { DuotoneImage } from 'react-duotone';
 
-class App extends Component {
-  render() {
-    return <DuotoneImage
-      className='image-preview'
-      alt='Your image description'
-      src='your-image.jpg'
-      primaryColor='#FBFBFB'
-      secondaryColor='#283B6B' />;
-  }
+function App() {
+  return (
+    <DuotoneImage
+      src="photo.jpg"
+      primaryColor="#FBFBFB"
+      secondaryColor="#283B6B"
+      alt="Duotone photo"
+      width={800}
+      height={600}
+    />
+  );
 }
-
-render(<App />, document.getElementById('app'));
 ```
 
-## Examples
+#### Props
 
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `src` | `string` | Yes | URL of the source image |
+| `primaryColor` | `string` | Yes | Hex color for the highlight (light) tone, e.g. `"#FBFBFB"` |
+| `secondaryColor` | `string` | Yes | Hex color for the shadow (dark) tone, e.g. `"#283B6B"` |
+| `...rest` | `React.ImgHTMLAttributes` | — | All standard `<img>` attributes are forwarded |
+
+### `createDuotoneImage` function
+
+Low-level utility that applies the duotone effect to a loaded `HTMLImageElement` and returns a data URL.
+
+```ts
+import { createDuotoneImage } from 'react-duotone';
+
+const img = new Image();
+img.src = 'photo.jpg';
+img.onload = () => {
+  const dataUrl = createDuotoneImage(img, '#FBFBFB', '#283B6B');
+  // use dataUrl as an <img src> or canvas source
+};
 ```
+
+## Running examples locally
+
+```bash
 npm install
 npm start
 ```
+
+## License
+
+MIT © [Florian Nagel](https://floriannagel.xyz/)

--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ function App() {
 
 #### Props
 
-| Prop | Type | Required | Description |
-|------|------|----------|-------------|
-| `src` | `string` | Yes | URL of the source image |
-| `primaryColor` | `string` | Yes | Hex color for the highlight (light) tone, e.g. `"#FBFBFB"` |
-| `secondaryColor` | `string` | Yes | Hex color for the shadow (dark) tone, e.g. `"#283B6B"` |
-| `...rest` | `React.ImgHTMLAttributes` | — | All standard `<img>` attributes are forwarded |
+| Prop             | Type                      | Required | Description                                                |
+| ---------------- | ------------------------- | -------- | ---------------------------------------------------------- |
+| `src`            | `string`                  | Yes      | URL of the source image                                    |
+| `primaryColor`   | `string`                  | Yes      | Hex color for the highlight (light) tone, e.g. `"#FBFBFB"` |
+| `secondaryColor` | `string`                  | Yes      | Hex color for the shadow (dark) tone, e.g. `"#283B6B"`     |
+| `...rest`        | `React.ImgHTMLAttributes` | —        | All standard `<img>` attributes are forwarded              |
 
 ### `createDuotoneImage` function
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# react-duotone
-
-[![Build Status](https://github.com/nagelflorian/react-duotone/actions/workflows/main.yml/badge.svg)](https://github.com/nagelflorian/react-duotone/actions) [![npm version](https://img.shields.io/npm/v/react-duotone.svg)](https://www.npmjs.com/package/react-duotone) [![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
+# React-Duotone [![Build Status](https://github.com/nagelflorian/react-duotone/actions/workflows/main.yml/badge.svg)](https://github.com/nagelflorian/react-duotone/actions) [![npm version](https://img.shields.io/npm/v/react-duotone.svg)](https://www.npmjs.com/package/react-duotone) [![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 
 Apply a [duotone](https://duotones.co/) color effect to images in React. Renders via HTML5 Canvas and returns the result as a data URL.
+
+![Example Duotone Image](https://cloud.githubusercontent.com/assets/7649376/19024780/e0fac730-890b-11e6-9640-1e2f604614e3.png)
 
 ## Requirements
 
@@ -12,8 +12,6 @@ Apply a [duotone](https://duotones.co/) color effect to images in React. Renders
 
 ```bash
 npm install react-duotone
-# or
-yarn add react-duotone
 ```
 
 ## Usage

--- a/dist/react-duotone.min.js.LICENSE.txt
+++ b/dist/react-duotone.min.js.LICENSE.txt
@@ -1,8 +1,0 @@
-/**
- * @license
- * Lodash <https://lodash.com/>
- * Copyright OpenJS Foundation and other contributors <https://openjsf.org/>
- * Released under MIT license <https://lodash.com/license>
- * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>
- * Copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
- */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-duotone",
-  "version": "2.1.1",
+  "version": "3.0.0",
   "description": "React Duotone Component",
   "main": "lib/main.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -16,13 +16,14 @@
     "bundle": "mkdir -p dist && npm run build && npm run build:umd && npm run build:umd:min",
     "type-check": "tsc --noEmit",
     "lint": "eslint src --ext .ts,.tsx",
-    "prettier": "prettier --single-quote --trailing-comma all --print-width 80 --write \"src/**/*.{ts,tsx}\"",
+    "prettier": "prettier --single-quote --trailing-comma all --print-width 80 --write \"src/**/*.{ts,tsx}\" \"**/*.md\"",
+    "prettier:check": "prettier --single-quote --trailing-comma all --print-width 80 --check \"src/**/*.{ts,tsx}\" \"**/*.md\"",
     "test": "jest --coverage",
     "start": "webpack-dev-server --static examples/",
     "prepare": "husky install"
   },
   "lint-staged": {
-    "*.{ts,tsx}": [
+    "*.{ts,tsx,md}": [
       "npm run prettier"
     ]
   },


### PR DESCRIPTION
## Summary

- Bumps version to `3.0.0`
- Refreshes README with updated usage examples, a props table, `createDuotoneImage` low-level API docs, and updated author link
- Dist files confirmed up-to-date via `npm run bundle`

## Test plan

- [ ] Review README rendering on GitHub
- [ ] Verify `npm run bundle` produces clean output
- [ ] Confirm `npm publish` dry-run looks correct before merging